### PR TITLE
Segurança: Adicionando development.rb ao gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pickle-email-*.html
 config/initializers/secret_token.rb
 config/secrets.yml
 /db/schema.rb
+config/environments/development.rb
 
 ## Environment normalisation:
 /.bundle

--- a/config/environments/development.rb.template
+++ b/config/environments/development.rb.template
@@ -42,7 +42,6 @@ Rails.application.configure do
   :port => 587,
   :domain => "sandboxcc645a9df82541d3b50acd6558a37194.mailgun.org",
   :user_name => "postmaster@sandboxcc645a9df82541d3b50acd6558a37194.mailgun.org",
-  :password => "05e5cefcd90a9f51ff875fd6717c5a1b"
+  :password => "[SENHA]"
 }
 end
-  


### PR DESCRIPTION
Ação necessária para evitar que nosso domínio do MailGun seja usado por terceiros como fonte de SPAM.
