### PR TITLE
Fix #135: user registration error.

### DIFF
--- a/app/mailers/personalized_devise_mailer.rb
+++ b/app/mailers/personalized_devise_mailer.rb
@@ -1,0 +1,6 @@
+class PersonalizedDeviseMailer < Devise::Mailer
+  helper :application # gives access to all helpers defined within `application_helper`.
+  include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+  default template_path: 'devise/mailer', # to make sure that your mailer uses the devise views
+          'Content-Transfer-Encoding' => '7bit'
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 class UserMailer < ActionMailer::Base
-	default from: "espelho.politico@gmail.com"
+	default from: 'espelho.politico@gmail.com', 'Content-Transfer-Encoding' => '7bit'
 
   def complaint_about_proposition(user, parliamentarian, proposition)
     @user = User.find(user)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,14 +35,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { :host => "localhost:3000" }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-  :authentication => :plain,
-  :address => "smtp.mailgun.org",
-  :port => 587,
-  :domain => "sandboxcc645a9df82541d3b50acd6558a37194.mailgun.org",
-  :user_name => "postmaster@sandboxcc645a9df82541d3b50acd6558a37194.mailgun.org",
-  :password => ENV["MAILGUN_PWD"]
-}
+  config.action_mailer.delivery_method = :file
 end
-  

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -17,7 +17,7 @@ Devise.setup do |config|
   config.mailer_sender = 'espelhopolitico@gmail.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'PersonalizedDeviseMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and


### PR DESCRIPTION
- Now the development environment send email to the file tmp/mails;
- The option 'Content-Transfer-Encoding' => '7bit' was set as default in
  devise mailer to fix encoding.
